### PR TITLE
Add CI workflow to auto-publish book on push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish Book
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Install TinyTeX
+        run: quarto install tinytex --yes
+
+      - name: Render book
+        run: quarto render
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_book


### PR DESCRIPTION
 ## Summary
  - Adds `.github/workflows/publish.yml` to automatically render and deploy the book when changes are pushed to `main`
  - Replaces manual `quarto publish gh-pages` with automated CI
  - Renders both HTML and PDF, deploys to `gh-pages` branch
  - Can also be triggered manually via workflow_dispatch

  ## How it works
  1. Installs Quarto and TinyTeX
  2. Runs `quarto render` (builds HTML + PDF)
  3. Pushes `_book/` contents to `gh-pages` branch

  No Python environment needed — notebook execution is disabled (`execute: enabled: false`), so notebooks render from pre-computed outputs.

  ## Prerequisites
  - GitHub Pages source must be set to `gh-pages` branch (already configured)