### PR TITLE
Improve README: relative links, chapter status, build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 [![Python: 3.x](https://img.shields.io/badge/python-3.x-blue.svg)](https://www.python.org/)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC_BY_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![EarthRISE: Development](https://img.shields.io/badge/EarthRISE-Development-b50000?labelColor=191f4c)](https://appliedsciences.nasa.gov/what-we-do/capacity-building/develop)
 
 <p align="center">
-  <img width="400" height="500" src="Images/Book_Cover.png">
+  <img width="400" height="500" src="Images/Book_Cover.png" alt="EarthRISE Applied AI and Deep Learning Book Cover">
 </p>
 
 The NASA EarthRISE program harnesses NASA Earth Action capabilities to deliver trusted solutions for sustained benefits to society. This book provides practitioners with a wide variety of applied examples of Remote Sensing Artificial Intelligence and Deep Learning approaches, with each chapter focusing on a specific problem set and spanning NASA Earth Action thematic areas.
@@ -17,29 +16,55 @@ The NASA EarthRISE program harnesses NASA Earth Action capabilities to deliver t
 
 ## Book Outline
 
-* [Introduction](https://nasa-earthrise.github.io/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/)
-* [1 — Data Preparation](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/02-Data-Preparation)
-* [Semantic Segmentation](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/03_Semantic_Segmentation)
-  * [2 — Crop Mapping](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/03_Semantic_Segmentation/01__Crop_Mapping)
-  * [3 — Selective Logging Detection](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/03_Semantic_Segmentation/02__Selective_Logging_Detection)
-* [4 — Object Detection](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/04_Object_Detection)
-* [Time Series](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/05_Time_Series)
-  * [5 — Soybean Yield Prediction](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/05_Time_Series/01__Soybean_Yield_Prediction)
-* [6 — Ecological Processes Simulation](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/06_Eco_Process_Sim)
-* [7 — Transfer Learning](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/07_Transfer_Learning)
-* [8 — Fusion](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/08_Fusion)
-* [9 — Downscaling](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/09_Downscaling)
-* [Future of Deep Learning and Foundational Models](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/10_Future)
-  * [10 — Evaluating Foundation Models Trained with Earth Observation Data](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/10_Future/01_Evaluating_Foundation_Models_Trained_with_Earth_Observation_Data)
-* [11 — Ethics and Artificial Intelligence](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/11_Ethics)
-* [12 — Conclusions](https://github.com/NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book/tree/main/12_Conclusions)
+* [Introduction](index.md)
+* [Data Preparation](02-Data-Preparation/) *(coming soon)*
+* **Semantic Segmentation**
+  * [Crop Mapping — Rice Mapping in Bhutan with U-Net](03_Semantic_Segmentation/01__Crop_Mapping/)
+  * [Selective Logging Detection with Very-High Resolution Imagery](03_Semantic_Segmentation/02__Selective_Logging_Detection/)
+* [Object Detection](04_Object_Detection/) *(coming soon)*
+* **Time Series**
+  * [Soybean Yield Prediction](05_Time_Series/01__Soybean_Yield_Prediction/)
+* **Ecological Processes Simulation**
+  * [Active Fire Detection with Bayesian Neural Networks](06_Eco_Process_Sim/01_Active_Fire_Detection/)
+* [Transfer Learning](07_Transfer_Learning/) *(coming soon)*
+* [Fusion](08_Fusion/) *(coming soon)*
+* [Downscaling](09_Downscaling/) *(coming soon)*
+* **Future of Deep Learning and Foundational Models**
+  * [Evaluating Foundation Models Trained with Earth Observation Data](10_Future/01_Evaluating_Foundation_Models_Trained_with_Earth_Observation_Data/)
+* [Ethics and Artificial Intelligence](11_Ethics/) *(coming soon)*
+* [Conclusions](12_Conclusions/) *(coming soon)*
+
+---
+
+## Building Locally
+
+The book is built with [Quarto](https://quarto.org/). To render locally:
+
+```bash
+# Render both HTML and PDF
+quarto render
+
+# Preview with live reload
+quarto preview
+
+# Render a single chapter
+quarto render 03_Semantic_Segmentation/01__Crop_Mapping/notebooks/Rice_Mapping_Bhutan_2021.ipynb
+```
+
+For PDF rendering you will also need TinyTeX:
+
+```bash
+quarto install tinytex
+```
+
+Notebook execution is disabled — chapters render from pre-computed outputs, so no Python environment is required to build the book.
 
 ---
 
 ## License and Distribution
 
-This book is distributed under the terms of the [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).
+This book is distributed under the terms of the [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/). You are free to share and adapt the material with appropriate attribution.
 
 ## Privacy & Terms of Use
 
-EarthRISE Applied Artificial Intelligence and Deep Learning Book abides by all of EarthRISE's privacy and terms of use.
+This book abides by NASA's privacy and terms of use, available at [nasa.gov/privacy](https://www.nasa.gov/privacy/).


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                       
- Replaced full GitHub URLs in the book outline with relative links — survives repo renames and is easier to read
- Marked placeholder chapters with *(coming soon)* — sets reader expectations for what's published vs. under development                                                                                                                                                                                         
- Bolded part headers (Semantic Segmentation, Time Series, Ecological Processes Simulation, Future of Deep Learning and Foundational Models) for clearer visual hierarchy                                                                                                                                        
- Used full chapter titles matching `_quarto.yml` (e.g., "Crop Mapping — Rice Mapping in Bhutan with U-Net")                                                                                                                                                                                                     
- Added a **Building Locally** section with `quarto render`/`preview` commands and TinyTeX setup                                                                                                                                                                                                                 
- Removed misleading MIT license badge (book is CC BY 4.0; no LICENSE file at root claimed MIT)                                                                                                                                                                                                                  
- Improved Privacy & Terms of Use section with a real link to NASA's privacy page                                                                                                                                                                                                                                
- Added missing `alt` text on the cover image 