### PR TITLE
 Fix chapter title rendering and update stale URLs

### DIFF
--- a/03_Semantic_Segmentation/02__Selective_Logging_Detection/notebooks/2_model_training.ipynb
+++ b/03_Semantic_Segmentation/02__Selective_Logging_Detection/notebooks/2_model_training.ipynb
@@ -68,8 +68,6 @@
    "source": [
     "# Selective Logging Detection with Deep Learning and Very-High Resolution Imagery\n",
     "\n",
-    "#### Authors: Osmar Yupanqui and Marvin Quispe\n",
-    "\n",
     "<br>\n",
     "\n",
     "## Part 2: Modeling\n",


### PR DESCRIPTION
  ## Summary

  Three small chapter-level cleanups, all in `03_Semantic_Segmentation/`:

  ### Selective Logging Detection — remove redundant authors heading
  The notebook had an explicit `#### Authors: Osmar Yupanqui and Marvin Quispe` markdown heading on top of the YAML frontmatter author block. This was rendering as an extra subsection (e.g., "3.0.0.1 Authors: ...") underneath the formal Authors/Affiliation block. Removed the redundant heading; the
  YAML-driven author block is now the single source.

  ### Crop Mapping — more descriptive chapter title
  The chapter previously had `# Crop Mapping` as the H1 with `## Rice mapping in Bhutan with U-Net using high resolution satellite imagery` as an H2 subtitle, which created an unnecessary numbered subsection. Combined into a single descriptive H1 matching the README naming:

  Crop Mapping — Rice Mapping in Bhutan with U-Net


  ### Crop Mapping — fix stale SERVIR URLs
  The Colab and GitHub badges in the Crop Mapping notebook still pointed to the old SERVIR org (`SERVIR/SERVIR-Applied-Deep-Learning-Book`), which 404s. Updated both to the current `NASA-EarthRISE/EarthRISE-Applied-Artificial-Intelligence-and-Deep-Learning-Book` repo.

  A repo-wide grep confirmed no other notebooks contain stale SERVIR URLs.

  ## Files changed
  - `03_Semantic_Segmentation/01__Crop_Mapping/notebooks/Rice_Mapping_Bhutan_2021.ipynb`
  - `03_Semantic_Segmentation/02__Selective_Logging_Detection/notebooks/2_model_training.ipynb`

  ## Verification
  - Both chapters render successfully via `quarto render`
  - No remaining `SERVIR/SERVIR-Applied-Deep-Learning-Book` references in any notebook or markdown file
